### PR TITLE
Add Hapi 5.5.1 workaround

### DIFF
--- a/built/app.js
+++ b/built/app.js
@@ -134,7 +134,7 @@ APP.action(async (args) => {
                     transactionTime: manifest.transactionTime,
                     outputFileCount: manifest.output.length,
                     deletedFileCount: manifest.deleted?.length || 0,
-                    errorFileCount: manifest.error.length
+                    errorFileCount: manifest.error?.length || 0
                 }
             });
         });

--- a/src/app.ts
+++ b/src/app.ts
@@ -156,7 +156,7 @@ APP.action(async (args: BulkDataClient.CLIOptions) => {
                     transactionTime : manifest.transactionTime,
                     outputFileCount : manifest.output.length,
                     deletedFileCount: manifest.deleted?.length || 0,
-                    errorFileCount  : manifest.error.length
+                    errorFileCount  : manifest.error.length || 0,
                 }
             })
         })


### PR DESCRIPTION
Add workaround for Hapi 5.5.1 [non-compliant Bulk Export response](https://build.fhir.org/ig/HL7/bulk-data/export.html#response---complete-status) (`error` attribute missing)