### PR TITLE
Containerization

### DIFF
--- a/.github/workflows/build-deliver.yaml
+++ b/.github/workflows/build-deliver.yaml
@@ -1,0 +1,27 @@
+# docker continuous delivery
+# deliver docker images to configured repo with tags to match branches and git tags
+---
+name: Build & Deliver
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout git commit
+        uses: actions/checkout@main
+
+      - name: Publish to GitHub Container Registry
+        # TODO: pin to hash
+        uses: elgohr/Publish-Docker-Github-Action@main
+        with:
+          name: ${{ github.repository }}
+          registry: ghcr.io
+
+          # GitHub actor
+          username: ${{ github.actor }}
+
+          # GitHub access token
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+          # create docker image tags to match git tags
+          tag_names: true

--- a/Docker.md
+++ b/Docker.md
@@ -1,0 +1,12 @@
+# Docker
+
+## Usage
+
+Invoke as follows to export all Measure and MeasureReport resources to the downloads directory
+
+    docker run \
+        --volume $PWD:/opt/node/app/downloads \
+    ghcr.io/uwcirg/bulk-data-client:main \
+        --global \
+        --fhir-url http://hapi.fhir.org/baseR4/ \
+        --_type Measure,MeasureReport

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:15
+
+# cache hack (very fragile): initially only copy list of project dependencies
+COPY --chown=node:node package.json package-lock.json /opt/node/
+
+# allow hot-reloading: install node dependencies to parent directory of code
+WORKDIR /opt/node
+USER node
+RUN npm install
+
+ENV SHOW_ERRORS=true
+
+# copy source code, switch to code directory
+COPY --chown=node:node . /opt/node/app
+WORKDIR /opt/node/app
+
+ENTRYPOINT [ \
+    "node", \
+        "--trace-exit", \
+        "--trace-warnings", \
+    ".", \
+    "--reporter=text" \
+]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+---
+version: "3.4"
+services:
+  export-client:
+    build:
+      context: .
+    volumes:
+      - ./downloads:/opt/node/app/downloads


### PR DESCRIPTION
- Add node docker image
  - Use artifacts built (`built/`) from Typescript codebase
    - Build (multistage) from Typescript in (`src/`) directly?
- Add continuous delivery to GHCR